### PR TITLE
AUTO-574 interpolate curvature at goal

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
@@ -55,6 +55,7 @@ struct Parameters
   bool allow_reversing;
   double max_robot_pose_search_dist;
   bool use_interpolation;
+  bool interpolate_curvature_at_goal;
   bool use_collision_detection;
   double transform_tolerance;
 };

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -90,6 +90,9 @@ ParameterHandler::ParameterHandler(
     node, plugin_name_ + ".use_interpolation",
     rclcpp::ParameterValue(true));
   declare_parameter_if_not_declared(
+    node, plugin_name_ + ".interpolate_curvature_at_goal",
+    rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(
     node, plugin_name_ + ".use_collision_detection",
     rclcpp::ParameterValue(true));
 
@@ -148,6 +151,9 @@ ParameterHandler::ParameterHandler(
   node->get_parameter(
     plugin_name_ + ".use_interpolation",
     params_.use_interpolation);
+  node->get_parameter(
+    plugin_name_ + ".interpolate_curvature_at_goal",
+    params_.interpolate_curvature_at_goal);
   node->get_parameter(
     plugin_name_ + ".use_collision_detection",
     params_.use_collision_detection);

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -187,12 +187,18 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
   // Handle special case of the carrot point being the last point of the path
   // We compute the curvature based on the interpolated position of the lookahead point
   if (params_->interpolate_curvature_at_goal
-      && carrot_pose.pose.position == transformed_plan.poses.back().pose.position
-      && transformed_plan.poses.size() > 1) {
+      && carrot_pose.pose.position == transformed_plan.poses.back().pose.position)
+  {
+    double end_path_orientation;
     geometry_msgs::msg::Point last_point = transformed_plan.poses.back().pose.position;
-    geometry_msgs::msg::Point previous_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
-    double end_path_orientation = atan2(last_point.y - previous_last_point.y,
-                                        last_point.x - previous_last_point.x);
+    if (transformed_plan.poses.size() == 1) {
+      // Handling only one pose left on path
+      end_path_orientation = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
+    } else {
+      geometry_msgs::msg::Point previous_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
+      end_path_orientation = atan2(last_point.y - previous_last_point.y,
+                                   last_point.x - previous_last_point.x);
+    }
     double distance_after_last = lookahead_dist - sqrt(carrot_dist2);
     geometry_msgs::msg::Point interpolated_carrot;
     interpolated_carrot.x = last_point.x + cos(end_path_orientation) * distance_after_last;
@@ -203,7 +209,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
     curvature = 2.0 * interpolated_carrot.y / interpolated_carrot_dist2;
   }
 
-  carrot_pub_->publish(createCarrotMsg(carrot_pose));
+  //carrot_pub_->publish(createCarrotMsg(carrot_pose));
 
   double linear_vel, angular_vel;
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -209,7 +209,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
     curvature = 2.0 * interpolated_carrot.y / interpolated_carrot_dist2;
   }
 
-  //carrot_pub_->publish(createCarrotMsg(carrot_pose));
+  carrot_pub_->publish(createCarrotMsg(carrot_pose));
 
   double linear_vel, angular_vel;
 

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -171,9 +171,6 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
 
   // Get the particular point on the path at the lookahead distance
   auto carrot_pose = getLookAheadPoint(lookahead_dist, transformed_plan);
-  carrot_pub_->publish(createCarrotMsg(carrot_pose));
-
-  double linear_vel, angular_vel;
 
   // Find distance^2 to look ahead point (carrot) in robot base frame
   // This is the chord length of the circle
@@ -186,6 +183,31 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
   if (carrot_dist2 > 0.001) {
     curvature = 2.0 * carrot_pose.pose.position.y / carrot_dist2;
   }
+
+  // Handle special case of the carrot point being the last point of the path
+  // We compute the curvature based on the interpolated position of the lookahead point
+  if (params_->interpolate_curvature_at_goal
+      && carrot_pose.pose.position == transformed_plan.poses.back().pose.position
+      && transformed_plan.poses.size() > 1) {
+    geometry_msgs::msg::Point last_point = transformed_plan.poses.back().pose.position;
+    geometry_msgs::msg::Point previous_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
+    double end_path_orientation = atan2(last_point.y - previous_last_point.y,
+                                        last_point.x - previous_last_point.x);
+    double distance_after_last = lookahead_dist - sqrt(carrot_dist2);
+    geometry_msgs::msg::Point interpolated_carrot;
+    interpolated_carrot.x = cos(end_path_orientation) * distance_after_last;
+    interpolated_carrot.y = sin(end_path_orientation) * distance_after_last;
+    double interpolated_carrot_dist2 =
+        (interpolated_carrot.x * interpolated_carrot.x) +
+        (interpolated_carrot.y * interpolated_carrot.y);
+    curvature = 2.0 * interpolated_carrot.y / interpolated_carrot_dist2;
+  }
+
+  carrot_pub_->publish(createCarrotMsg(carrot_pose));
+
+  double linear_vel, angular_vel;
+
+
 
   // Setting the velocity direction
   double sign = 1.0;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -195,8 +195,8 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
                                         last_point.x - previous_last_point.x);
     double distance_after_last = lookahead_dist - sqrt(carrot_dist2);
     geometry_msgs::msg::Point interpolated_carrot;
-    interpolated_carrot.x = cos(end_path_orientation) * distance_after_last;
-    interpolated_carrot.y = sin(end_path_orientation) * distance_after_last;
+    interpolated_carrot.x = last_point.x + cos(end_path_orientation) * distance_after_last;
+    interpolated_carrot.y = last_point.y + sin(end_path_orientation) * distance_after_last;
     double interpolated_carrot_dist2 =
         (interpolated_carrot.x * interpolated_carrot.x) +
         (interpolated_carrot.y * interpolated_carrot.y);


### PR DESCRIPTION
https://dexory.atlassian.net/browse/AUTO-574
Targets and depends on https://github.com/botsandus/navigation2/pull/5
This PR modifies the nav2 RPP controller with a new parameter `interpolate_curvature_at_goal`, `false` by default, which when set to `true` uses the last two poses of the path to compute an interpolated carrot which will then be used to compute the curvature. This interpolation based curvature is only used when the end of the path (goal) is closer to the robot than the `lookahead_distance`, and is needed to maintain the same level of smooth angular speed generation up to the very end of the path