### PR TITLE
AUTO-595 Use rotate to Path on RPP

### DIFF
--- a/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
+++ b/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_regulated_pure_pursuit_controller)
 
 find_package(ament_cmake REQUIRED)
+find_package(nav2_amcl REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
@@ -30,6 +31,7 @@ set(dependencies
   nav2_core
   tf2
   tf2_geometry_msgs
+  nav2_amcl
 )
 
 set(library_name nav2_regulated_pure_pursuit_controller)

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
@@ -50,6 +50,7 @@ struct Parameters
   double regulated_linear_scaling_min_radius;
   double regulated_linear_scaling_min_speed;
   bool use_rotate_to_heading;
+  bool use_rotate_to_path;
   double max_angular_accel;
   double rotate_to_heading_min_angle;
   bool allow_reversing;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -76,9 +76,16 @@ public:
     const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose) const;
 
-  void setPlan(const nav_msgs::msg::Path & path) {global_plan_ = path;}
+  void setPlan(const nav_msgs::msg::Path & path) {
+    global_plan_ = path;
+    if (path.poses.size() > 1) {
+      previous_last_pose_ = *std::prev(path.poses.end(),2);
+    }
+  }
 
   nav_msgs::msg::Path getPlan() {return global_plan_;}
+
+  geometry_msgs::msg::PoseStamped getBeforeLastPose() {return previous_last_pose_;}
 
 protected:
   /**
@@ -92,6 +99,7 @@ protected:
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   nav_msgs::msg::Path global_plan_;
+  geometry_msgs::msg::PoseStamped previous_last_pose_;
 };
 
 }  // namespace nav2_regulated_pure_pursuit_controller

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -79,7 +79,7 @@ public:
   void setPlan(const nav_msgs::msg::Path & path) {
     global_plan_ = path;
     if (path.poses.size() > 1) {
-      previous_last_pose_ = *std::prev(path.poses.end(),2);
+      previous_last_pose_ = *std::prev(path.poses.end(), 2);
     }
   }
 

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -76,7 +76,8 @@ public:
     const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose) const;
 
-  void setPlan(const nav_msgs::msg::Path & path) {
+  void setPlan(const nav_msgs::msg::Path & path)
+  {
     global_plan_ = path;
     if (path.poses.size() > 1) {
       previous_last_pose_ = *std::prev(path.poses.end(), 2);

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -210,6 +210,8 @@ protected:
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>>
   carrot_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>>
+  interpolated_carrot_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> carrot_arc_pub_;
   std::unique_ptr<nav2_regulated_pure_pursuit_controller::PathHandler> path_handler_;
   std::unique_ptr<nav2_regulated_pure_pursuit_controller::ParameterHandler> param_handler_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -134,7 +134,7 @@ protected:
    * @return Whether should rotate to path heading
    */
   bool shouldRotateToPath(
-    const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path);
+    const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path, double sign);
 
   /**
    * @brief Whether robot should rotate to final goal orientation

--- a/nav2_regulated_pure_pursuit_controller/package.xml
+++ b/nav2_regulated_pure_pursuit_controller/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>nav2_amcl</depend>
   <depend>nav2_common</depend>
   <depend>nav2_core</depend>
   <depend>nav2_util</depend>

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -78,6 +78,8 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".use_rotate_to_heading", rclcpp::ParameterValue(true));
   declare_parameter_if_not_declared(
+    node, plugin_name_ + ".use_rotate_to_path", rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(
     node, plugin_name_ + ".rotate_to_heading_min_angle", rclcpp::ParameterValue(0.785));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_angular_accel", rclcpp::ParameterValue(3.2));
@@ -138,6 +140,7 @@ ParameterHandler::ParameterHandler(
     plugin_name_ + ".regulated_linear_scaling_min_speed",
     params_.regulated_linear_scaling_min_speed);
   node->get_parameter(plugin_name_ + ".use_rotate_to_heading", params_.use_rotate_to_heading);
+  node->get_parameter(plugin_name_ + ".use_rotate_to_path", params_.use_rotate_to_path);
   node->get_parameter(
     plugin_name_ + ".rotate_to_heading_min_angle", params_.rotate_to_heading_min_angle);
   node->get_parameter(plugin_name_ + ".max_angular_accel", params_.max_angular_accel);
@@ -234,6 +237,8 @@ ParameterHandler::dynamicParametersCallback(
         params_.use_cost_regulated_linear_velocity_scaling = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_collision_detection") {
         params_.use_collision_detection = parameter.as_bool();
+      } else if (name == plugin_name_ + ".use_rotate_to_path") {
+        params_.use_rotate_to_path = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_rotate_to_heading") {
         if (parameter.as_bool() && params_.allow_reversing) {
           RCLCPP_WARN(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -74,6 +74,8 @@ void RegulatedPurePursuitController::configure(
 
   global_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
   carrot_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>("lookahead_point", 1);
+  interpolated_carrot_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>(
+    "interpolated_lookahead_point", 1);
 }
 
 void RegulatedPurePursuitController::cleanup()
@@ -85,6 +87,7 @@ void RegulatedPurePursuitController::cleanup()
     plugin_name_.c_str());
   global_path_pub_.reset();
   carrot_pub_.reset();
+  interpolated_carrot_pub_.reset();
 }
 
 void RegulatedPurePursuitController::activate()
@@ -96,6 +99,7 @@ void RegulatedPurePursuitController::activate()
     plugin_name_.c_str());
   global_path_pub_->on_activate();
   carrot_pub_->on_activate();
+  interpolated_carrot_pub_->on_activate();
 }
 
 void RegulatedPurePursuitController::deactivate()
@@ -107,6 +111,7 @@ void RegulatedPurePursuitController::deactivate()
     plugin_name_.c_str());
   global_path_pub_->on_deactivate();
   carrot_pub_->on_deactivate();
+  interpolated_carrot_pub_->on_deactivate();
 }
 
 std::unique_ptr<geometry_msgs::msg::PointStamped> RegulatedPurePursuitController::createCarrotMsg(
@@ -187,49 +192,65 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
 
   // Handle special case of the carrot point being the last point of the path
   // We compute the curvature based on the interpolated position of the lookahead point
+  // Interpolation is done based on the orientation of the vector connecting the last two poses
+  geometry_msgs::msg::PoseStamped interpolated_carrot = carrot_pose;
   if (params_->interpolate_curvature_at_goal
       && carrot_pose.pose.position == transformed_plan.poses.back().pose.position)
   {
     double end_path_orientation;
+    double distance_after_last_pose = lookahead_dist - sqrt(carrot_dist2);
+
     geometry_msgs::msg::Point last_point = transformed_plan.poses.back().pose.position;
+    geometry_msgs::msg::Point before_last_point;
+
     if (transformed_plan.poses.size() == 1) {
-      // Handling only one pose left on path
-      end_path_orientation = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
+      // Handle only one pose left on path
+      distance_after_last_pose = lookahead_dist;
+      geometry_msgs::msg::PoseStamped before_last_pose = path_handler_->getBeforeLastPose();
+      before_last_pose.header.stamp = rclcpp::Time(0);
+      path_handler_->transformPose(
+            transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
+      before_last_point = before_last_pose.pose.position;
     } else {
-      geometry_msgs::msg::Point previous_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
-      end_path_orientation = atan2(last_point.y - previous_last_point.y,
-                                   last_point.x - previous_last_point.x);
+      before_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
     }
-    double distance_after_last = lookahead_dist - sqrt(carrot_dist2);
-    geometry_msgs::msg::Point interpolated_carrot;
-    interpolated_carrot.x = last_point.x + cos(end_path_orientation) * distance_after_last;
-    interpolated_carrot.y = last_point.y + sin(end_path_orientation) * distance_after_last;
+
+    end_path_orientation = atan2(last_point.y - before_last_point.y,
+                                 last_point.x - before_last_point.x);
+
+    interpolated_carrot.pose.position.x = last_point.x +
+        cos(end_path_orientation) * distance_after_last_pose;
+    interpolated_carrot.pose.position.y = last_point.y +
+        sin(end_path_orientation) * distance_after_last_pose;
+
     double interpolated_carrot_dist2 =
-        (interpolated_carrot.x * interpolated_carrot.x) +
-        (interpolated_carrot.y * interpolated_carrot.y);
-    curvature = 2.0 * interpolated_carrot.y / interpolated_carrot_dist2;
+        (interpolated_carrot.pose.position.x * interpolated_carrot.pose.position.x) +
+        (interpolated_carrot.pose.position.y * interpolated_carrot.pose.position.y);
+    curvature = 2.0 * interpolated_carrot.pose.position.y / interpolated_carrot_dist2;
+
+    interpolated_carrot_pub_->publish(createCarrotMsg(interpolated_carrot));
   }
 
   carrot_pub_->publish(createCarrotMsg(carrot_pose));
 
   double linear_vel, angular_vel;
 
-
-
   // Setting the velocity direction
-  double sign = 1.0;
+  double sign, interpolated_sign = 1.0;
   if (params_->allow_reversing) {
     sign = carrot_pose.pose.position.x >= 0.0 ? 1.0 : -1.0;
+    interpolated_sign = interpolated_carrot.pose.position.x >= 0.0 ? 1.0 : -1.0;
   }
 
   linear_vel = params_->desired_linear_vel;
 
   // Make sure we're in compliance with basic constraints
+  // Using interpolated carrot for rotate to Path (if interpolate_curvature_at_goal = true)
   double angle_to_heading;
   if (shouldRotateToGoalHeading(carrot_pose)) {
     double angle_to_goal = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
     rotateToHeading(linear_vel, angular_vel, angle_to_goal, speed);
-  } else if (shouldRotateToPath(carrot_pose, angle_to_heading, sign)) {
+  } else if (shouldRotateToPath(interpolated_carrot, angle_to_heading, interpolated_sign)) {
     rotateToHeading(linear_vel, angular_vel, angle_to_heading, speed);
   } else {
     applyConstraints(
@@ -292,6 +313,10 @@ void RegulatedPurePursuitController::rotateToHeading(
   const double min_feasible_angular_speed = curr_speed.angular.z - params_->max_angular_accel * dt;
   const double max_feasible_angular_speed = curr_speed.angular.z + params_->max_angular_accel * dt;
   angular_vel = std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+
+  RCLCPP_INFO_STREAM(
+    logger_,
+    "rotateToHeading angular_vel" << angular_vel);
 }
 
 geometry_msgs::msg::Point RegulatedPurePursuitController::circleSegmentIntersection(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -313,10 +313,6 @@ void RegulatedPurePursuitController::rotateToHeading(
   const double min_feasible_angular_speed = curr_speed.angular.z - params_->max_angular_accel * dt;
   const double max_feasible_angular_speed = curr_speed.angular.z + params_->max_angular_accel * dt;
   angular_vel = std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
-
-  RCLCPP_INFO_STREAM(
-    logger_,
-    "rotateToHeading angular_vel" << angular_vel);
 }
 
 geometry_msgs::msg::Point RegulatedPurePursuitController::circleSegmentIntersection(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -194,8 +194,8 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
   // We compute the curvature based on the interpolated position of the lookahead point
   // Interpolation is done based on the orientation of the vector connecting the last two poses
   geometry_msgs::msg::PoseStamped interpolated_carrot = carrot_pose;
-  if (params_->interpolate_curvature_at_goal
-      && carrot_pose.pose.position == transformed_plan.poses.back().pose.position)
+  if (params_->interpolate_curvature_at_goal &&
+    carrot_pose.pose.position == transformed_plan.poses.back().pose.position)
   {
     double end_path_orientation;
     double distance_after_last_pose = lookahead_dist - sqrt(carrot_dist2);
@@ -209,23 +209,24 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
       geometry_msgs::msg::PoseStamped before_last_pose = path_handler_->getBeforeLastPose();
       before_last_pose.header.stamp = rclcpp::Time(0);
       path_handler_->transformPose(
-            transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
+        transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
       before_last_point = before_last_pose.pose.position;
     } else {
       before_last_point = std::prev(transformed_plan.poses.end(), 2)->pose.position;
     }
 
-    end_path_orientation = atan2(last_point.y - before_last_point.y,
-                                 last_point.x - before_last_point.x);
+    end_path_orientation = atan2(
+      last_point.y - before_last_point.y,
+      last_point.x - before_last_point.x);
 
     interpolated_carrot.pose.position.x = last_point.x +
-        cos(end_path_orientation) * distance_after_last_pose;
+      cos(end_path_orientation) * distance_after_last_pose;
     interpolated_carrot.pose.position.y = last_point.y +
-        sin(end_path_orientation) * distance_after_last_pose;
+      sin(end_path_orientation) * distance_after_last_pose;
 
     double interpolated_carrot_dist2 =
-        (interpolated_carrot.pose.position.x * interpolated_carrot.pose.position.x) +
-        (interpolated_carrot.pose.position.y * interpolated_carrot.pose.position.y);
+      (interpolated_carrot.pose.position.x * interpolated_carrot.pose.position.x) +
+      (interpolated_carrot.pose.position.y * interpolated_carrot.pose.position.y);
     curvature = 2.0 * interpolated_carrot.pose.position.y / interpolated_carrot_dist2;
 
     interpolated_carrot_pub_->publish(createCarrotMsg(interpolated_carrot));
@@ -282,11 +283,11 @@ bool RegulatedPurePursuitController::shouldRotateToPath(
   const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path, double sign)
 {
   // Whether we should rotate robot to rough path heading
-  if (sign >=0) {
+  if (sign >= 0) {
     angle_to_path = atan2(carrot_pose.pose.position.y, carrot_pose.pose.position.x);
   } else {
     angle_to_path = nav2_amcl::angleutils::normalize(
-          atan2(carrot_pose.pose.position.y, carrot_pose.pose.position.x) + M_PI);
+      atan2(carrot_pose.pose.position.y, carrot_pose.pose.position.x) + M_PI);
   }
   return params_->use_rotate_to_path &&
          fabs(angle_to_path) > params_->rotate_to_heading_min_angle;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -212,7 +212,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
             transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
       before_last_point = before_last_pose.pose.position;
     } else {
-      before_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
+      before_last_point = std::prev(transformed_plan.poses.end(), 2)->pose.position;
     }
 
     end_path_orientation = atan2(last_point.y - before_last_point.y,

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -77,7 +77,7 @@ public:
   bool shouldRotateToPathWrapper(
     const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path)
   {
-    return shouldRotateToPath(carrot_pose, angle_to_path);
+    return shouldRotateToPath(carrot_pose, angle_to_path, 1.0);
   }
 
   bool shouldRotateToGoalHeadingWrapper(const geometry_msgs::msg::PoseStamped & carrot_pose)


### PR DESCRIPTION
This PR adds the parameter `use_rotate_to_path` to make the RPP controller orient the robot in the direction of the path before driving along it. It is essentially similar to `use_rotate_to_path` param but without orienting the path to the end pose goal orientation.
Logic to make this new param compatible with the curve interpolation at the end of the path needed to be added (along with dealing wiht the corner case of having only one pose left on the path).
Needed for smooth segment navigation