### PR TITLE
AUTO-604 Fix using different frame for global and local costmap

### DIFF
--- a/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
+++ b/nav2_mppi_controller/include/nav2_mppi_controller/tools/path_handler.hpp
@@ -115,23 +115,13 @@ protected:
   transformToGlobalPlanFrame(const geometry_msgs::msg::PoseStamped & pose);
 
   /**
-    * @brief Transform a plan to the costmap reference frame
-    * @param begin Start of path to transform
-    * @param end End of path to transform
-    * @param stamp Timestamp to use for transformation
-    * @return output path in costmap reference frame
-    */
-  nav_msgs::msg::Path
-  transformPlanPosesToCostmapFrame(
-    PathIterator begin, PathIterator end,
-    const builtin_interfaces::msg::Time & stamp);
-
-  /**
     * @brief Get global plan within window of the local costmap size
     * @param global_pose Robot pose
-    * @return Range of path iterators belonging to the path within costmap window
+    * @return plan transformed in the costmap frame and iterator to the first pose of the global
+    * plan (for pruning)
     */
-  PathRange getGlobalPlanConsideringBounds(const geometry_msgs::msg::PoseStamped & global_pose);
+  std::pair<nav_msgs::msg::Path, PathIterator> getGlobalPlanConsideringBoundsInCostmapFrame(
+    const geometry_msgs::msg::PoseStamped & global_pose);
 
   /**
     * @brief Prune global path to only interesting portions

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -57,9 +57,9 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
       return euclidean_distance(global_pose, ps);
     });
 
-  nav_msgs::msg::Path transformedPlan;
-  transformedPlan.header.frame_id = costmap_->getGlobalFrameID();
-  transformedPlan.header.stamp = global_pose.header.stamp;
+  nav_msgs::msg::Path transformed_plan;
+  transformed_plan.header.frame_id = costmap_->getGlobalFrameID();
+  transformed_plan.header.stamp = global_pose.header.stamp;
 
   unsigned int mx, my;
   // Find the furthest relevent pose on the path to consider within costmap
@@ -69,7 +69,7 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
     // Distance relative to robot pose check
     auto distance = euclidean_distance(global_pose, *global_plan_pose);
     if (distance >= prune_distance_) {
-      return {transformedPlan, closest_point};
+      return {transformed_plan, closest_point};
     }
 
     // Transform from global plan frame to costmap frame
@@ -81,14 +81,14 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
     if (!costmap_->getCostmap()->worldToMap(
         costmap_plan_pose.pose.position.x, costmap_plan_pose.pose.position.y, mx, my))
     {
-      return {transformedPlan, closest_point};
+      return {transformed_plan, closest_point};
     }
 
     // Filling the transformed plan to return with the transformed pose
-    transformedPlan.poses.push_back(costmap_plan_pose);
+    transformed_plan.poses.push_back(costmap_plan_pose);
   }
 
-  return {transformedPlan, closest_point};
+  return {transformed_plan, closest_point};
 }
 
 geometry_msgs::msg::PoseStamped PathHandler::transformToGlobalPlanFrame(

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -37,10 +37,12 @@ void PathHandler::initialize(
   getParam(transform_tolerance_, "transform_tolerance", 0.1);
 }
 
-PathRange PathHandler::getGlobalPlanConsideringBounds(
+std::pair<nav_msgs::msg::Path, PathIterator>
+PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
   const geometry_msgs::msg::PoseStamped & global_pose)
 {
   using nav2_util::geometry_utils::euclidean_distance;
+
   auto begin = global_plan_.poses.begin();
   auto end = global_plan_.poses.end();
 
@@ -55,19 +57,37 @@ PathRange PathHandler::getGlobalPlanConsideringBounds(
       return euclidean_distance(global_pose, ps);
     });
 
-  // Find the furthest relevent point on the path to consider within costmap
-  // bounds
-  const auto * costmap = costmap_->getCostmap();
-  unsigned int mx, my;
-  auto last_point =
-    std::find_if(
-    closest_point, end, [&](const geometry_msgs::msg::PoseStamped & global_plan_pose) {
-      auto distance = euclidean_distance(global_pose, global_plan_pose);
-      return distance >= prune_distance_ || !costmap->worldToMap(
-        global_plan_pose.pose.position.x, global_plan_pose.pose.position.y, mx, my);
-    });
+  nav_msgs::msg::Path transformedPlan;
+  transformedPlan.header.frame_id = costmap_->getGlobalFrameID();
+  transformedPlan.header.stamp = global_pose.header.stamp;
 
-  return {closest_point, last_point};
+  unsigned int mx, my;
+  // Find the furthest relevent pose on the path to consider within costmap
+  // bounds
+  // Transforming it to the costmap frame in the same loop
+  for (auto global_plan_pose = closest_point; global_plan_pose != end; ++global_plan_pose) {
+    // Distance relative to robot pose check
+    auto distance = euclidean_distance(global_pose, *global_plan_pose);
+    if (distance >= prune_distance_) {
+      return {transformedPlan, closest_point};
+    }
+
+    // Transform from global plan frame to costmap frame
+    geometry_msgs::msg::PoseStamped costmap_plan_pose;
+    transformPose(costmap_->getGlobalFrameID(), *global_plan_pose, costmap_plan_pose);
+
+    // Check if pose is inside the costmap
+    if (!costmap_->getCostmap()->worldToMap(
+        costmap_plan_pose.pose.position.x, costmap_plan_pose.pose.position.y, mx, my))
+    {
+      return {transformedPlan, closest_point};
+    }
+
+    // Filling the transformed plan to return with the transformed pose
+    transformedPlan.poses.push_back(costmap_plan_pose);
+  }
+
+  return {transformedPlan, closest_point};
 }
 
 geometry_msgs::msg::PoseStamped PathHandler::transformToGlobalPlanFrame(
@@ -92,12 +112,7 @@ nav_msgs::msg::Path PathHandler::transformPath(
   // Find relevent bounds of path to use
   geometry_msgs::msg::PoseStamped global_pose =
     transformToGlobalPlanFrame(robot_pose);
-  auto [lower_bound, upper_bound] = getGlobalPlanConsideringBounds(global_pose);
-
-  // Transform these bounds into the local costmap frame and prune older points
-  const auto & stamp = global_pose.header.stamp;
-  nav_msgs::msg::Path transformed_plan =
-    transformPlanPosesToCostmapFrame(lower_bound, upper_bound, stamp);
+  auto [transformed_plan, lower_bound] = getGlobalPlanConsideringBoundsInCostmapFrame(global_pose);
 
   pruneGlobalPlan(lower_bound);
 
@@ -134,31 +149,6 @@ double PathHandler::getMaxCostmapDist()
   const auto & costmap = costmap_->getCostmap();
   return std::max(costmap->getSizeInCellsX(), costmap->getSizeInCellsY()) *
          costmap->getResolution() / 2.0;
-}
-
-nav_msgs::msg::Path PathHandler::transformPlanPosesToCostmapFrame(
-  PathIterator begin, PathIterator end, const builtin_interfaces::msg::Time & stamp)
-{
-  std::string frame = costmap_->getGlobalFrameID();
-  auto transformToFrame = [&](const auto & global_plan_pose) {
-      geometry_msgs::msg::PoseStamped from_pose;
-      geometry_msgs::msg::PoseStamped to_pose;
-
-      from_pose.header.frame_id = global_plan_.header.frame_id;
-      from_pose.header.stamp = stamp;
-      from_pose.pose = global_plan_pose.pose;
-
-      transformPose(frame, from_pose, to_pose);
-      return to_pose;
-    };
-
-  nav_msgs::msg::Path plan;
-  plan.header.frame_id = frame;
-  plan.header.stamp = stamp;
-
-  std::transform(begin, end, std::back_inserter(plan.poses), transformToFrame);
-
-  return plan;
 }
 
 void PathHandler::setPath(const nav_msgs::msg::Path & plan)

--- a/nav2_mppi_controller/src/path_handler.cpp
+++ b/nav2_mppi_controller/src/path_handler.cpp
@@ -74,6 +74,7 @@ PathHandler::getGlobalPlanConsideringBoundsInCostmapFrame(
 
     // Transform from global plan frame to costmap frame
     geometry_msgs::msg::PoseStamped costmap_plan_pose;
+    global_plan_pose->header.stamp = global_pose.header.stamp;
     transformPose(costmap_->getGlobalFrameID(), *global_plan_pose, costmap_plan_pose);
 
     // Check if pose is inside the costmap

--- a/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
+++ b/nav2_regulated_pure_pursuit_controller/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(nav2_regulated_pure_pursuit_controller)
 
 find_package(ament_cmake REQUIRED)
+find_package(nav2_amcl REQUIRED)
 find_package(nav2_common REQUIRED)
 find_package(nav2_core REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
@@ -30,6 +31,7 @@ set(dependencies
   nav2_core
   tf2
   tf2_geometry_msgs
+  nav2_amcl
 )
 
 set(library_name nav2_regulated_pure_pursuit_controller)

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/parameter_handler.hpp
@@ -50,6 +50,7 @@ struct Parameters
   double regulated_linear_scaling_min_radius;
   double regulated_linear_scaling_min_speed;
   bool use_rotate_to_heading;
+  bool use_rotate_to_path;
   double max_angular_accel;
   double rotate_to_heading_min_angle;
   bool allow_reversing;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -76,9 +76,16 @@ public:
     const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose) const;
 
-  void setPlan(const nav_msgs::msg::Path & path) {global_plan_ = path;}
+  void setPlan(const nav_msgs::msg::Path & path) {
+    global_plan_ = path;
+    if (path.poses.size() > 1) {
+      previous_last_pose_ = *std::prev(path.poses.end(),2);
+    }
+  }
 
   nav_msgs::msg::Path getPlan() {return global_plan_;}
+
+  geometry_msgs::msg::PoseStamped getBeforeLastPose() {return previous_last_pose_;}
 
 protected:
   /**
@@ -92,6 +99,7 @@ protected:
   std::shared_ptr<tf2_ros::Buffer> tf_;
   std::shared_ptr<nav2_costmap_2d::Costmap2DROS> costmap_ros_;
   nav_msgs::msg::Path global_plan_;
+  geometry_msgs::msg::PoseStamped previous_last_pose_;
 };
 
 }  // namespace nav2_regulated_pure_pursuit_controller

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -79,7 +79,7 @@ public:
   void setPlan(const nav_msgs::msg::Path & path) {
     global_plan_ = path;
     if (path.poses.size() > 1) {
-      previous_last_pose_ = *std::prev(path.poses.end(),2);
+      previous_last_pose_ = *std::prev(path.poses.end(), 2);
     }
   }
 

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/path_handler.hpp
@@ -76,7 +76,8 @@ public:
     const geometry_msgs::msg::PoseStamped & in_pose,
     geometry_msgs::msg::PoseStamped & out_pose) const;
 
-  void setPlan(const nav_msgs::msg::Path & path) {
+  void setPlan(const nav_msgs::msg::Path & path)
+  {
     global_plan_ = path;
     if (path.poses.size() > 1) {
       previous_last_pose_ = *std::prev(path.poses.end(), 2);

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -210,6 +210,8 @@ protected:
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> global_path_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>>
   carrot_pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<geometry_msgs::msg::PointStamped>>
+  interpolated_carrot_pub_;
   std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Path>> carrot_arc_pub_;
   std::unique_ptr<nav2_regulated_pure_pursuit_controller::PathHandler> path_handler_;
   std::unique_ptr<nav2_regulated_pure_pursuit_controller::ParameterHandler> param_handler_;

--- a/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
+++ b/nav2_regulated_pure_pursuit_controller/include/nav2_regulated_pure_pursuit_controller/regulated_pure_pursuit_controller.hpp
@@ -134,7 +134,7 @@ protected:
    * @return Whether should rotate to path heading
    */
   bool shouldRotateToPath(
-    const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path);
+    const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path, double sign);
 
   /**
    * @brief Whether robot should rotate to final goal orientation

--- a/nav2_regulated_pure_pursuit_controller/package.xml
+++ b/nav2_regulated_pure_pursuit_controller/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>nav2_amcl</depend>
   <depend>nav2_common</depend>
   <depend>nav2_core</depend>
   <depend>nav2_util</depend>

--- a/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/parameter_handler.cpp
@@ -78,6 +78,8 @@ ParameterHandler::ParameterHandler(
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".use_rotate_to_heading", rclcpp::ParameterValue(true));
   declare_parameter_if_not_declared(
+    node, plugin_name_ + ".use_rotate_to_path", rclcpp::ParameterValue(false));
+  declare_parameter_if_not_declared(
     node, plugin_name_ + ".rotate_to_heading_min_angle", rclcpp::ParameterValue(0.785));
   declare_parameter_if_not_declared(
     node, plugin_name_ + ".max_angular_accel", rclcpp::ParameterValue(3.2));
@@ -138,6 +140,7 @@ ParameterHandler::ParameterHandler(
     plugin_name_ + ".regulated_linear_scaling_min_speed",
     params_.regulated_linear_scaling_min_speed);
   node->get_parameter(plugin_name_ + ".use_rotate_to_heading", params_.use_rotate_to_heading);
+  node->get_parameter(plugin_name_ + ".use_rotate_to_path", params_.use_rotate_to_path);
   node->get_parameter(
     plugin_name_ + ".rotate_to_heading_min_angle", params_.rotate_to_heading_min_angle);
   node->get_parameter(plugin_name_ + ".max_angular_accel", params_.max_angular_accel);
@@ -234,6 +237,8 @@ ParameterHandler::dynamicParametersCallback(
         params_.use_cost_regulated_linear_velocity_scaling = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_collision_detection") {
         params_.use_collision_detection = parameter.as_bool();
+      } else if (name == plugin_name_ + ".use_rotate_to_path") {
+        params_.use_rotate_to_path = parameter.as_bool();
       } else if (name == plugin_name_ + ".use_rotate_to_heading") {
         if (parameter.as_bool() && params_.allow_reversing) {
           RCLCPP_WARN(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -74,6 +74,8 @@ void RegulatedPurePursuitController::configure(
 
   global_path_pub_ = node->create_publisher<nav_msgs::msg::Path>("received_global_plan", 1);
   carrot_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>("lookahead_point", 1);
+  interpolated_carrot_pub_ = node->create_publisher<geometry_msgs::msg::PointStamped>(
+    "interpolated_lookahead_point", 1);
 }
 
 void RegulatedPurePursuitController::cleanup()
@@ -85,6 +87,7 @@ void RegulatedPurePursuitController::cleanup()
     plugin_name_.c_str());
   global_path_pub_.reset();
   carrot_pub_.reset();
+  interpolated_carrot_pub_.reset();
 }
 
 void RegulatedPurePursuitController::activate()
@@ -96,6 +99,7 @@ void RegulatedPurePursuitController::activate()
     plugin_name_.c_str());
   global_path_pub_->on_activate();
   carrot_pub_->on_activate();
+  interpolated_carrot_pub_->on_activate();
 }
 
 void RegulatedPurePursuitController::deactivate()
@@ -107,6 +111,7 @@ void RegulatedPurePursuitController::deactivate()
     plugin_name_.c_str());
   global_path_pub_->on_deactivate();
   carrot_pub_->on_deactivate();
+  interpolated_carrot_pub_->on_deactivate();
 }
 
 std::unique_ptr<geometry_msgs::msg::PointStamped> RegulatedPurePursuitController::createCarrotMsg(
@@ -187,49 +192,65 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
 
   // Handle special case of the carrot point being the last point of the path
   // We compute the curvature based on the interpolated position of the lookahead point
+  // Interpolation is done based on the orientation of the vector connecting the last two poses
+  geometry_msgs::msg::PoseStamped interpolated_carrot = carrot_pose;
   if (params_->interpolate_curvature_at_goal
       && carrot_pose.pose.position == transformed_plan.poses.back().pose.position)
   {
     double end_path_orientation;
+    double distance_after_last_pose = lookahead_dist - sqrt(carrot_dist2);
+
     geometry_msgs::msg::Point last_point = transformed_plan.poses.back().pose.position;
+    geometry_msgs::msg::Point before_last_point;
+
     if (transformed_plan.poses.size() == 1) {
-      // Handling only one pose left on path
-      end_path_orientation = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
+      // Handle only one pose left on path
+      distance_after_last_pose = lookahead_dist;
+      geometry_msgs::msg::PoseStamped before_last_pose = path_handler_->getBeforeLastPose();
+      before_last_pose.header.stamp = rclcpp::Time(0);
+      path_handler_->transformPose(
+            transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
+      before_last_point = before_last_pose.pose.position;
     } else {
-      geometry_msgs::msg::Point previous_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
-      end_path_orientation = atan2(last_point.y - previous_last_point.y,
-                                   last_point.x - previous_last_point.x);
+      before_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
     }
-    double distance_after_last = lookahead_dist - sqrt(carrot_dist2);
-    geometry_msgs::msg::Point interpolated_carrot;
-    interpolated_carrot.x = last_point.x + cos(end_path_orientation) * distance_after_last;
-    interpolated_carrot.y = last_point.y + sin(end_path_orientation) * distance_after_last;
+
+    end_path_orientation = atan2(last_point.y - before_last_point.y,
+                                 last_point.x - before_last_point.x);
+
+    interpolated_carrot.pose.position.x = last_point.x +
+        cos(end_path_orientation) * distance_after_last_pose;
+    interpolated_carrot.pose.position.y = last_point.y +
+        sin(end_path_orientation) * distance_after_last_pose;
+
     double interpolated_carrot_dist2 =
-        (interpolated_carrot.x * interpolated_carrot.x) +
-        (interpolated_carrot.y * interpolated_carrot.y);
-    curvature = 2.0 * interpolated_carrot.y / interpolated_carrot_dist2;
+        (interpolated_carrot.pose.position.x * interpolated_carrot.pose.position.x) +
+        (interpolated_carrot.pose.position.y * interpolated_carrot.pose.position.y);
+    curvature = 2.0 * interpolated_carrot.pose.position.y / interpolated_carrot_dist2;
+
+    interpolated_carrot_pub_->publish(createCarrotMsg(interpolated_carrot));
   }
 
   carrot_pub_->publish(createCarrotMsg(carrot_pose));
 
   double linear_vel, angular_vel;
 
-
-
   // Setting the velocity direction
-  double sign = 1.0;
+  double sign, interpolated_sign = 1.0;
   if (params_->allow_reversing) {
     sign = carrot_pose.pose.position.x >= 0.0 ? 1.0 : -1.0;
+    interpolated_sign = interpolated_carrot.pose.position.x >= 0.0 ? 1.0 : -1.0;
   }
 
   linear_vel = params_->desired_linear_vel;
 
   // Make sure we're in compliance with basic constraints
+  // Using interpolated carrot for rotate to Path (if interpolate_curvature_at_goal = true)
   double angle_to_heading;
   if (shouldRotateToGoalHeading(carrot_pose)) {
     double angle_to_goal = tf2::getYaw(transformed_plan.poses.back().pose.orientation);
     rotateToHeading(linear_vel, angular_vel, angle_to_goal, speed);
-  } else if (shouldRotateToPath(carrot_pose, angle_to_heading, sign)) {
+  } else if (shouldRotateToPath(interpolated_carrot, angle_to_heading, interpolated_sign)) {
     rotateToHeading(linear_vel, angular_vel, angle_to_heading, speed);
   } else {
     applyConstraints(
@@ -292,6 +313,10 @@ void RegulatedPurePursuitController::rotateToHeading(
   const double min_feasible_angular_speed = curr_speed.angular.z - params_->max_angular_accel * dt;
   const double max_feasible_angular_speed = curr_speed.angular.z + params_->max_angular_accel * dt;
   angular_vel = std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
+
+  RCLCPP_INFO_STREAM(
+    logger_,
+    "rotateToHeading angular_vel" << angular_vel);
 }
 
 geometry_msgs::msg::Point RegulatedPurePursuitController::circleSegmentIntersection(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -313,10 +313,6 @@ void RegulatedPurePursuitController::rotateToHeading(
   const double min_feasible_angular_speed = curr_speed.angular.z - params_->max_angular_accel * dt;
   const double max_feasible_angular_speed = curr_speed.angular.z + params_->max_angular_accel * dt;
   angular_vel = std::clamp(angular_vel, min_feasible_angular_speed, max_feasible_angular_speed);
-
-  RCLCPP_INFO_STREAM(
-    logger_,
-    "rotateToHeading angular_vel" << angular_vel);
 }
 
 geometry_msgs::msg::Point RegulatedPurePursuitController::circleSegmentIntersection(

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -194,8 +194,8 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
   // We compute the curvature based on the interpolated position of the lookahead point
   // Interpolation is done based on the orientation of the vector connecting the last two poses
   geometry_msgs::msg::PoseStamped interpolated_carrot = carrot_pose;
-  if (params_->interpolate_curvature_at_goal
-      && carrot_pose.pose.position == transformed_plan.poses.back().pose.position)
+  if (params_->interpolate_curvature_at_goal &&
+    carrot_pose.pose.position == transformed_plan.poses.back().pose.position)
   {
     double end_path_orientation;
     double distance_after_last_pose = lookahead_dist - sqrt(carrot_dist2);
@@ -209,23 +209,24 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
       geometry_msgs::msg::PoseStamped before_last_pose = path_handler_->getBeforeLastPose();
       before_last_pose.header.stamp = rclcpp::Time(0);
       path_handler_->transformPose(
-            transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
+        transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
       before_last_point = before_last_pose.pose.position;
     } else {
       before_last_point = std::prev(transformed_plan.poses.end(), 2)->pose.position;
     }
 
-    end_path_orientation = atan2(last_point.y - before_last_point.y,
-                                 last_point.x - before_last_point.x);
+    end_path_orientation = atan2(
+      last_point.y - before_last_point.y,
+      last_point.x - before_last_point.x);
 
     interpolated_carrot.pose.position.x = last_point.x +
-        cos(end_path_orientation) * distance_after_last_pose;
+      cos(end_path_orientation) * distance_after_last_pose;
     interpolated_carrot.pose.position.y = last_point.y +
-        sin(end_path_orientation) * distance_after_last_pose;
+      sin(end_path_orientation) * distance_after_last_pose;
 
     double interpolated_carrot_dist2 =
-        (interpolated_carrot.pose.position.x * interpolated_carrot.pose.position.x) +
-        (interpolated_carrot.pose.position.y * interpolated_carrot.pose.position.y);
+      (interpolated_carrot.pose.position.x * interpolated_carrot.pose.position.x) +
+      (interpolated_carrot.pose.position.y * interpolated_carrot.pose.position.y);
     curvature = 2.0 * interpolated_carrot.pose.position.y / interpolated_carrot_dist2;
 
     interpolated_carrot_pub_->publish(createCarrotMsg(interpolated_carrot));
@@ -282,11 +283,11 @@ bool RegulatedPurePursuitController::shouldRotateToPath(
   const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path, double sign)
 {
   // Whether we should rotate robot to rough path heading
-  if (sign >=0) {
+  if (sign >= 0) {
     angle_to_path = atan2(carrot_pose.pose.position.y, carrot_pose.pose.position.x);
   } else {
     angle_to_path = nav2_amcl::angleutils::normalize(
-          atan2(carrot_pose.pose.position.y, carrot_pose.pose.position.x) + M_PI);
+      atan2(carrot_pose.pose.position.y, carrot_pose.pose.position.x) + M_PI);
   }
   return params_->use_rotate_to_path &&
          fabs(angle_to_path) > params_->rotate_to_heading_min_angle;

--- a/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
+++ b/nav2_regulated_pure_pursuit_controller/src/regulated_pure_pursuit_controller.cpp
@@ -212,7 +212,7 @@ geometry_msgs::msg::TwistStamped RegulatedPurePursuitController::computeVelocity
             transformed_plan.poses.back().header.frame_id, before_last_pose, before_last_pose);
       before_last_point = before_last_pose.pose.position;
     } else {
-      before_last_point = std::prev(transformed_plan.poses.end(),2)->pose.position;
+      before_last_point = std::prev(transformed_plan.poses.end(), 2)->pose.position;
     }
 
     end_path_orientation = atan2(last_point.y - before_last_point.y,

--- a/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
+++ b/nav2_regulated_pure_pursuit_controller/test/test_regulated_pp.cpp
@@ -77,7 +77,7 @@ public:
   bool shouldRotateToPathWrapper(
     const geometry_msgs::msg::PoseStamped & carrot_pose, double & angle_to_path)
   {
-    return shouldRotateToPath(carrot_pose, angle_to_path);
+    return shouldRotateToPath(carrot_pose, angle_to_path, 1.0);
   }
 
   bool shouldRotateToGoalHeadingWrapper(const geometry_msgs::msg::PoseStamped & carrot_pose)


### PR DESCRIPTION
Mirror of nav2 PR: https://github.com/ros-planning/navigation2/pull/3425

It is currently impossible to use a different global frame for the global and local costmap.
The use of `worldToMap` to check if the pose is inside the costmap works only if the pose to check is referenced relative to the costmap frame: https://github.com/ros-planning/navigation2/blob/9dca1cfa60af9cdc4f6111db960bae72fd85b17c/nav2_mppi_controller/src/path_handler.cpp#L66

Proposed fix is to replace `transformPlanPosesToCostmapFrame` and `getGlobalPlanConsideringBounds` by `getGlobalPlanConsideringBoundsInCostmapFrame` in order not to have to transform the pose from the global plan/global costmap frame to the controller/local costmap frame twice.