### PR TITLE
AUTO-763 fix smoother accel decel

### DIFF
--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -206,9 +206,17 @@ double VelocitySmoother::applyConstraints(
   double v_component_max;
   double v_component_min;
 
-  if (abs(v_cmd) >= abs(v_curr)) {
-    v_component_max = accel / smoothing_frequency_;
-    v_component_min = -accel / smoothing_frequency_;
+  // Accelerating if magnitude of v_cmd is above magnitude of v_curr
+  // and if v_cmd and v_curr have the same sign (i.e. speed is NOT passing through 0.0)
+  // Deccelerating otherwise
+  if (v_curr * v_cmd >= 0.0) {
+    if (abs(v_cmd) >= abs(v_curr)) {
+      v_component_max = accel / smoothing_frequency_;
+      v_component_min = -accel / smoothing_frequency_;
+    } else {
+      v_component_max = -decel / smoothing_frequency_;
+      v_component_min = decel / smoothing_frequency_;
+    }
   } else {
     v_component_max = -decel / smoothing_frequency_;
     v_component_min = decel / smoothing_frequency_;

--- a/nav2_velocity_smoother/src/velocity_smoother.cpp
+++ b/nav2_velocity_smoother/src/velocity_smoother.cpp
@@ -202,8 +202,18 @@ double VelocitySmoother::applyConstraints(
   const double accel, const double decel, const double eta)
 {
   double dv = v_cmd - v_curr;
-  const double v_component_max = accel / smoothing_frequency_;
-  const double v_component_min = decel / smoothing_frequency_;
+
+  double v_component_max;
+  double v_component_min;
+
+  if (abs(v_cmd) >= abs(v_curr)) {
+    v_component_max = accel / smoothing_frequency_;
+    v_component_min = -accel / smoothing_frequency_;
+  } else {
+    v_component_max = -decel / smoothing_frequency_;
+    v_component_min = decel / smoothing_frequency_;
+  }
+
   return v_curr + std::clamp(eta * dv, v_component_min, v_component_max);
 }
 


### PR DESCRIPTION
Mirror of https://github.com/ros-planning/navigation2/pull/3529

To test:

`ros2 launch arri_bringup twist_pipeline.launch.py `
edited with (low max linear accel): 

```
    velocity_smoother = Node(
        package='nav2_velocity_smoother',
        name='root_velocity_smoother',
        executable='velocity_smoother',
        parameters=[
            # {'use_sim_time': use_sim_time},
            {'smoothing_frequency': 20.0},
            {'scale_velocities': False},
            {'feedback': 'OPEN_LOOP'},
            {'max_velocity': [0.5, 0.0, 0.8]},
            {'min_velocity': [-0.5, 0.0, -0.8]},
            {'velocity_timeout': 0.5},
            {'max_accel': [0.1, 0.0, 0.2]},
            {'max_decel': [-0.5, 0.0, -1.2]},
            ],
        remappings=[
            ('cmd_vel', 'cmd_vel_protected'),
            ('cmd_vel_smoothed', 'cmd_vel')],
        output='screen')
```

Generate twist on `/cmd_vel_protected` with:

`ros2 run rqt_robot_steering rqt_robot_steering `

![image](https://user-images.githubusercontent.com/15727892/231132518-3e1eb08d-4fa9-49dd-a7ab-2f8b3611896d.png)

Observe output with plotjuggler (test config: [smoother_test.zip](https://github.com/botsandus/navigation2/files/11199361/smoother_test.zip) )
![Screenshot from 2023-04-11 11-16-23](https://user-images.githubusercontent.com/15727892/231132859-c19af9c0-84a3-443b-ae1c-2f1e7608ea84.png)

