### PR TITLE
AUTO-1147 Height Zone based tower actuation 

### DIFF
--- a/nav2_behaviors/plugins/wait.cpp
+++ b/nav2_behaviors/plugins/wait.cpp
@@ -30,21 +30,19 @@ Wait::~Wait() = default;
 
 Status Wait::onRun(const std::shared_ptr<const WaitAction::Goal> command)
 {
-  wait_end_ = std::chrono::steady_clock::now() +
-    rclcpp::Duration(command->time).to_chrono<std::chrono::nanoseconds>();
+  wait_end_ = node_.lock()->now() + rclcpp::Duration(command->time);
   return Status::SUCCEEDED;
 }
 
 Status Wait::onCycleUpdate()
 {
-  auto current_point = std::chrono::steady_clock::now();
-  auto time_left =
-    std::chrono::duration_cast<std::chrono::nanoseconds>(wait_end_ - current_point).count();
+  auto current_point = node_.lock()->now();
+  auto time_left = wait_end_ - current_point;
 
-  feedback_->time_left = rclcpp::Duration(rclcpp::Duration::from_nanoseconds(time_left));
+  feedback_->time_left = time_left;
   action_server_->publish_feedback(feedback_);
 
-  if (time_left > 0) {
+  if (time_left.nanoseconds() > 0) {
     return Status::RUNNING;
   } else {
     return Status::SUCCEEDED;

--- a/nav2_behaviors/plugins/wait.hpp
+++ b/nav2_behaviors/plugins/wait.hpp
@@ -53,7 +53,7 @@ public:
   Status onCycleUpdate() override;
 
 protected:
-  std::chrono::time_point<std::chrono::steady_clock> wait_end_;
+  rclcpp::Time wait_end_;
   WaitAction::Feedback::SharedPtr feedback_;
 };
 


### PR DESCRIPTION
https://dexory.atlassian.net/browse/AUTO-1147

See https://github.com/botsandus/auto-navigation/pull/48 for full story

- Use ros clock instead of wall time to have consistent Wait behavior 

- Not needed anymore as replaced by WaitForRobotToStop in our BT, but merged in nav2 main anyway: https://github.com/ros-planning/navigation2/issues/3780