### PR TITLE
Enable RunsOn for feature repo CI

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,4 @@
+# NOTE: RunsOn only reads the configuration file from the repository default branch.
+# Thus new settings will not be applied until the changes are merged into the default branch.
+
+_extends: auto-sandbox


### PR DESCRIPTION
And extend it using the auto-sandbox repo as the default config. This config needs to be merged into the default branch before it can take effect, and enable RunsOn to pick up workflow jobs from this repo, as I'd like to add some more repos to test my feature CI workflows.