### PR TITLE
AT-167 AMCL map switch bug

### DIFF
--- a/nav2_amcl/src/map/map.c
+++ b/nav2_amcl/src/map/map.c
@@ -49,6 +49,9 @@ map_t * map_alloc(void)
   // Allocate storage for main map
   map->cells = (map_cell_t *) NULL;
 
+  // Explicitly set the max_occ_dist to 0
+  map->max_occ_dist = 0.0;
+
   return map;
 }
 


### PR DESCRIPTION
JIRA: https://dexory.atlassian.net/browse/AT-167

This explicitly sets the `max_occ_dist` to 0.0 at allocation.

### Context 

We were seeing some issues in our new version when we switch to a map that is not the correct map and switch back to the original map, the localisation freaked out. (Very visibly this happens with the U9 map more, details on the ticket for reproducing the issue)

After some experimentation, I found that reverting this commit: https://github.com/botsandus/navigation2/commit/c4b46a829de1bc20ebf542e6ef83f4947d4aa995, seems to fix the issue. 

That commit is used to save time from needlessly rebuilding the cspace every time and to only do it if something changed. 

However, the [`max_occ_dist`](https://github.com/botsandus/navigation2/blob/f92c266504c980f5ef00b71a7e5795d1311f1355/nav2_amcl/include/nav2_amcl/map/map.hpp#L77) member of the `map_t` struct was never properly initialised to 0.

The Theory that best fits is that when we switch maps,  it is possible that the same memory address used to represent part of the map is being reused for the variable, and because it is not properly initialised, this "skips" updating the cspace because the value in it does not satisfy the condition. 

After this change, that bug seems to go away and the localisation seems all good. 


